### PR TITLE
Update sonarcloud.yml

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -49,22 +49,25 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: Install ReportGenerator
-        run: dotnet tool install --global dotnet-reportgenerator-globaltool
+      - name: Install Coverlet
+        run: dotnet tool install --global coverlet.console
 
       # Run tests and collect code coverage
       - name: Run tests and collect coverage
-        run: dotnet test --collect:"Code Coverage" --results-directory TestResults
-
-      - name: Convert coverage report to OpenCover format
-        run: reportgenerator -reports:TestResults/**/*.coverage -targetdir:coverage-report -reporttypes:opencover
-
+        run: |
+          dotnet test \
+          --collect:"XPlat Code Coverage" \
+          --results-directory TestResults \
+          /p:CollectCoverage=true \
+          /p:CoverletOutputFormat=opencover \
+          /p:CoverletOutput=TestResults/coverage.opencover.xml
+          
       # Perform SonarQube analysis
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"nhan925__underscore-Ex-BE" /o:"nhan925" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=coverage-report/coverage.opencover.xml /d:sonar.exclusions=**/*.html,**/*.sql
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"nhan925__underscore-Ex-BE" /o:"nhan925" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=TestResults/coverage.opencover.xml /d:sonar.exclusions=**/*.html,**/*.sql
           dotnet build
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -55,7 +55,7 @@ jobs:
       # Run tests and collect code coverage
       - name: Run tests and collect coverage
         run: |
-          dotnet test --collect:"XPlat Code Coverage" --results-directory TestResults /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/coverage.opencover.xml
+          dotnet test --collect:"XPlat Code Coverage" --results-directory TestResults
           
       # Perform SonarQube analysis
       - name: Build and analyze
@@ -63,6 +63,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"nhan925__underscore-Ex-BE" /o:"nhan925" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=TestResults/coverage.opencover.xml /d:sonar.exclusions=**/*.html,**/*.sql
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"nhan925__underscore-Ex-BE" /o:"nhan925" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.cobertura.reportsPaths=TestResults/**/coverage.cobertura.xml /d:sonar.exclusions=**/*.html,**/*.sql
           dotnet build
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -55,12 +55,7 @@ jobs:
       # Run tests and collect code coverage
       - name: Run tests and collect coverage
         run: |
-          dotnet test \
-          --collect:"XPlat Code Coverage" \
-          --results-directory TestResults \
-          /p:CollectCoverage=true \
-          /p:CoverletOutputFormat=opencover \
-          /p:CoverletOutput=TestResults/coverage.opencover.xml
+          dotnet test --collect:"XPlat Code Coverage" --results-directory TestResults /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/coverage.opencover.xml
           
       # Perform SonarQube analysis
       - name: Build and analyze

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -49,9 +49,15 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
+      - name: Install ReportGenerator
+        run: dotnet tool install --global dotnet-reportgenerator-globaltool
+
       # Run tests and collect code coverage
       - name: Run tests and collect coverage
-        run: dotnet test --collect:"Code Coverage"
+        run: dotnet test --collect:"Code Coverage" --results-directory TestResults
+
+      - name: Convert coverage report to OpenCover format
+        run: reportgenerator -reports:TestResults/**/*.coverage -targetdir:coverage-report -reporttypes:opencover
 
       # Perform SonarQube analysis
       - name: Build and analyze
@@ -59,6 +65,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"nhan925__underscore-Ex-BE" /o:"nhan925" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml /d:sonar.exclusions=**/*.html,**/*.sql
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"nhan925__underscore-Ex-BE" /o:"nhan925" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=coverage-report/coverage.opencover.xml /d:sonar.exclusions=**/*.html,**/*.sql
           dotnet build
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
This pull request updates the SonarCloud workflow configuration to enhance code coverage reporting and analysis. The changes include installing a new tool, improving test result handling, and refining the coverage report format for better integration with SonarCloud.

### Enhancements to SonarCloud workflow:

* Added a step to install the `dotnet-reportgenerator-globaltool` for converting code coverage reports into OpenCover format. (`.github/workflows/sonarcloud.yml`, [.github/workflows/sonarcloud.ymlR52-R68](diffhunk://#diff-5895707186d21bd3672c2faf7743c1cd2d656de088cdec80dc676ed8e3f22bceR52-R68))
* Updated the `dotnet test` command to specify a results directory for better organization of test results. (`.github/workflows/sonarcloud.yml`, [.github/workflows/sonarcloud.ymlR52-R68](diffhunk://#diff-5895707186d21bd3672c2faf7743c1cd2d656de088cdec80dc676ed8e3f22bceR52-R68))
* Introduced a step to convert the coverage report to OpenCover format using `reportgenerator`, ensuring compatibility with SonarCloud. (`.github/workflows/sonarcloud.yml`, [.github/workflows/sonarcloud.ymlR52-R68](diffhunk://#diff-5895707186d21bd3672c2faf7743c1cd2d656de088cdec80dc676ed8e3f22bceR52-R68))
* Adjusted the SonarQube analysis configuration to point to the newly generated OpenCover report in the `coverage-report` directory. (`.github/workflows/sonarcloud.yml`, [.github/workflows/sonarcloud.ymlR52-R68](diffhunk://#diff-5895707186d21bd3672c2faf7743c1cd2d656de088cdec80dc676ed8e3f22bceR52-R68))