### PR TITLE
fix StudentServiceTests and FacultyServiceTests

### DIFF
--- a/src/student_management_api_tests/ServicesTests/FacultyServiceTests.cs
+++ b/src/student_management_api_tests/ServicesTests/FacultyServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using student_management_api.Contracts.IRepositories;
+using student_management_api.Exceptions;
 using student_management_api.Models.DTO;
 using student_management_api.Services;
 using System.Collections.Generic;
@@ -133,21 +134,21 @@ public class FacultyServiceTests
 
     #region AddFaculty Tests
     [Fact]
-    public async Task AddFaculty_ValidName_ReturnsAddedRowCount()
+    public async Task AddFaculty_ValidName_ReturnsFacultyId()
     {
         // Arrange
         string facultyName = "Physics";
-        int expectedRowsAffected = 1;
+        int expectedFacultyId = 10;
 
         _mockFacultyRepository
             .Setup(repo => repo.AddFaculty(facultyName))
-            .ReturnsAsync(expectedRowsAffected);
+            .ReturnsAsync(expectedFacultyId);
 
         // Act
         var result = await _facultyService.AddFaculty(facultyName);
 
         // Assert
-        Assert.Equal(expectedRowsAffected, result);
+        Assert.Equal(expectedFacultyId, result);
         _mockFacultyRepository.Verify(
             repo => repo.AddFaculty(facultyName),
             Times.Once()
@@ -155,24 +156,17 @@ public class FacultyServiceTests
     }
 
     [Fact]
-    public async Task AddFaculty_EmptyName_ReturnsZero()
+    public async Task AddFaculty_InsertFailed_ThrowsException()
     {
         // Arrange
-        string facultyName = "";
-        int expectedRowsAffected = 0;
-
+        string facultyName = "Physics";
         _mockFacultyRepository
             .Setup(repo => repo.AddFaculty(facultyName))
-            .ReturnsAsync(expectedRowsAffected);
+            .ThrowsAsync(new OperationFailedException("failed_to_add_faculty"));
 
-        // Act
-        var result = await _facultyService.AddFaculty(facultyName);
-
-        // Assert
-        Assert.Equal(expectedRowsAffected, result);
-        _mockFacultyRepository.Verify(
-            repo => repo.AddFaculty(facultyName),
-            Times.Once()
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationFailedException>(
+            () => _facultyService.AddFaculty(facultyName)
         );
     }
     #endregion

--- a/src/student_management_api_tests/ServicesTests/StudentServiceTests.cs
+++ b/src/student_management_api_tests/ServicesTests/StudentServiceTests.cs
@@ -62,7 +62,7 @@ public class StudentServiceTests
             .ReturnsAsync((string)null!);
 
         // Act
-        await Assert.ThrowsAsync<Exception>(() =>
+        await Assert.ThrowsAsync<OperationFailedException>(() =>
             _studentService.AddStudent(request));
     }
 


### PR DESCRIPTION
This pull request updates test cases in the `FacultyServiceTests` and `StudentServiceTests` to improve error handling and align with updated service behavior. The most significant changes include modifying test cases for adding faculty to reflect a shift from returning row counts to returning faculty IDs, and ensuring proper exception handling for failed operations.

### Updates to `FacultyServiceTests`:

* Changed the `AddFaculty_ValidName_ReturnsAddedRowCount` test to `AddFaculty_ValidName_ReturnsFacultyId`, reflecting the updated service behavior of returning a faculty ID instead of a row count.
* Replaced the `AddFaculty_EmptyName_ReturnsZero` test with `AddFaculty_InsertFailed_ThrowsException`, which now expects an `OperationFailedException` to be thrown when the faculty insertion fails.
* Added the `OperationFailedException` import to support the new exception handling in tests.

### Updates to `StudentServiceTests`:

* Updated the `AddStudent_WhenRepositoryFails_ThrowsException` test to expect an `OperationFailedException` instead of a generic `Exception`, ensuring more specific error handling.